### PR TITLE
Add keyboard support for save as

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -50,7 +50,7 @@ public class Application : Gtk.Application {
         this.add_action (open_document_action);
 
         SimpleAction saveas_action = new SimpleAction ("saveas", null);
-        set_accels_for_action ("app.saveas", {"<Control>s"});
+        set_accels_for_action ("app.saveas", {"<Control><Shift>s"});
         add_action (saveas_action);
         saveas_action.activate.connect (() => {
             unowned var window = this.get_active_window () as AppWindow;

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -33,7 +33,7 @@ public class AppWindow : Gtk.Window {
         };
         var save_as_button = new Gtk.Button.from_icon_name ("document-save-as") {
             tooltip_markup = Granite.markup_accel_tooltip (
-                    {"<Control>s"},
+                    {"<Control><Shift>s"},
                     _("Save as")
             )
         };


### PR DESCRIPTION
## Changes Summary
- Add keyboard support for save as. This was a TODO in #9
- Use Ctrl + Shift + S hotkey which is common for save as rather than Ctrl + S which is commonly used for save
