### PR TITLE
Suggestion: Do not increment created_documents flag when failed to open

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -89,7 +89,12 @@ public class Application : Gtk.Application {
                 print (unsaved_doc);
                 string path = Path.build_filename (data_dir_path, unsaved_doc);
                 File file = File.new_for_path (path);
-                open_file (file);
+
+                bool ret = open_file (file);
+                if (!ret) {
+                    continue;
+                }
+
                 created_documents++;
             }
 
@@ -160,15 +165,16 @@ public class Application : Gtk.Application {
 
     }
 
-    public void open_file (File file) {
-        if (file.query_file_type (FileQueryInfoFlags.NONE) == FileType.REGULAR) {
-            var new_window = new AppWindow (file);
-            add_window (new_window);
-            new_window.present ();
-        } else {
+    public bool open_file (File file) {
+        if (file.query_file_type (FileQueryInfoFlags.NONE) != FileType.REGULAR) {
             warning ("Couldn't open, not a regular file.");
+            return false;
         }
 
+        var new_window = new AppWindow (file);
+        add_window (new_window);
+        new_window.present ();
+        return true;
     }
 
     public void on_open_document () {


### PR DESCRIPTION
This rarely happens, but this PR changes the behavior of the app when there is only one directory under the data directory.

## Before
The app quits without showing any windows:

```
user@elementary-8:~/work/slate$ rm -rf /home/user/.local/share/slate
user@elementary-8:~/work/slate$ mkdir -p /home/user/.local/share/slate/foo
user@elementary-8:~/work/slate$ G_MESSAGES_DEBUG=all io.github.wpkelso.slate 
(io.github.wpkelso.slate:8269): GLib-GIO-DEBUG: 23:24:27.241: Using cross-namespace EXTERNAL authentication (this will deadlock if server is GDBus < 2.73.3)
libEGL warning: DRI3: Screen seems not DRI3 capable
libEGL warning: DRI2: failed to authenticate
libEGL warning: DRI3: Screen seems not DRI3 capable
MESA: error: ZINK: failed to choose pdev
libEGL warning: egl: failed to create dri2 screen
(io.github.wpkelso.slate:8269): GLib-GIO-DEBUG: 23:24:27.285: _g_io_module_get_default: Found default implementation gvfs (GDaemonVfs) for ‘gio-vfs’
(io.github.wpkelso.slate:8269): Gtk-DEBUG: 23:24:27.305: Connecting to session manager
** (io.github.wpkelso.slate:8269): DEBUG: 23:24:27.327: Application.vala:76: Datadir path: /home/user/.local/share/slate
** (io.github.wpkelso.slate:8269): DEBUG: 23:24:27.327: Application.vala:128: Do we have a data directory?
** (io.github.wpkelso.slate:8269): DEBUG: 23:24:27.327: Application.vala:135: Yes, data directory exists!
foo
** (io.github.wpkelso.slate:8269): WARNING **: 23:24:27.327: Application.vala:169: Couldn't open, not a regular file.
user@elementary-8:~/work/slate$ 
```

## After
The app shows a "New Document" window because no regular file found under the data directory.
