### PR TITLE
Add error dialog when opening a non-text document

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -145,17 +145,17 @@ public class Application : Gtk.Application {
         if (!Utils.check_if_valid_text_file (file)) {
             var window = get_windows ().first ().data;
             var error_dialog = new
-            Granite.MessageDialog.with_image_from_icon_name (
-                "Couldn't open file",
-                "The specified file is not a valid text file",
-                "dialog-error"
-            ) {
-                transient_for = window
-            };
+                Granite.MessageDialog.with_image_from_icon_name (
+                        "Couldn't open file",
+                        "The specified file is not a valid text file",
+                        "dialog-error"
+                        ) {
+                    transient_for = window
+                };
 
             error_dialog.response.connect ((response_id) => {
-                error_dialog.destroy ();
-            });
+                    error_dialog.destroy ();
+                    });
 
             error_dialog.show ();
             return false;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -141,8 +141,23 @@ public class Application : Gtk.Application {
     }
 
     public bool open_window_with_file (File file) {
-        if (file.query_file_type (FileQueryInfoFlags.NONE) != FileType.REGULAR) {
-            warning ("Couldn't open, not a regular file.");
+
+        if (!Utils.check_if_valid_text_file (file)) {
+            var window = get_windows ().first ().data;
+            var error_dialog = new
+            Granite.MessageDialog.with_image_from_icon_name (
+                "Couldn't open file",
+                "The specified file is not a valid text file",
+                "dialog-error"
+            ) {
+                transient_for = window
+            };
+
+            error_dialog.response.connect ((response_id) => {
+                error_dialog.destroy ();
+            });
+
+            error_dialog.show ();
             return false;
         }
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -33,4 +33,24 @@
             warning ("Failed to prepare target data directory %s\n", err.message);
         }
     }
+
+    public static bool check_if_valid_text_file (File file) {
+        try {
+            FileInfo info = file.query_info ("*", NOFOLLOW_SYMLINKS);
+
+            var content_type = info.get_content_type (); 
+            if (info.get_file_type () == FileType.REGULAR && 
+                    ContentType.is_a (content_type, "text/*") || 
+                    ContentType.is_a (content_type, "application/x-zerosize")
+               ) { 
+                return true;
+            }
+
+        } catch (Error err) {
+            warning ("Failed to get file information: %s", err.message);
+        }
+
+
+        return false;
+    }
  }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -50,7 +50,6 @@
             warning ("Failed to get file information: %s", err.message);
         }
 
-
         return false;
     }
  }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -38,11 +38,11 @@
         try {
             FileInfo info = file.query_info ("*", NOFOLLOW_SYMLINKS);
 
-            var content_type = info.get_content_type (); 
-            if (info.get_file_type () == FileType.REGULAR && 
-                    ContentType.is_a (content_type, "text/*") || 
+            var content_type = info.get_content_type ();
+            if (info.get_file_type () == FileType.REGULAR &&
+                    ContentType.is_a (content_type, "text/*") ||
                     ContentType.is_a (content_type, "application/x-zerosize")
-               ) { 
+               ) {
                 return true;
             }
 


### PR DESCRIPTION
Actually let the user know that the file can't be opened, rather than silently failing. Also, make sure a file is a valid text file we can open, so we don't blow up non-text files.